### PR TITLE
White button not showing correct cursor

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,6 +66,7 @@ p {
 a {
     font-family: Circular Light;
     color: var(--darkblue);
+    cursor: pointer;
 }
 
 .splash {


### PR DESCRIPTION
On the live website I noticed that your white-button at the top of your page doesn't show the correct cursor due to the href missing from the tag.

![image](https://user-images.githubusercontent.com/9423347/79894475-7dcac400-83d3-11ea-951d-4e5c60da19de.png)

I updated the style.css file and just added a line to force all <a> tags to have a pointing cursor.

![image](https://user-images.githubusercontent.com/9423347/79894595-afdc2600-83d3-11ea-948d-8fd270a9fd27.png)
